### PR TITLE
feat: Add support of custom NHC config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ nhc_upgrade: false
 #   * || check_hw_cpuinfo 2 8 8
 #   * || check_hw_physmem 1k 1TB
 
+# List of custom NHC configuration files
+# Example:
+# nhc_custom_configs:
+#   - name: nhc_epilog.conf
+#     config:
+#       * || check_ib_link_raw_ber
+#   # Remove a configuration file
+#   - name: nhc_foo.conf
+#     state: absent
+
 # List of NHC environment variables
 # See https://github.com/mej/nhc?tab=readme-ov-file#supported-variables
 # Example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@
 #   * || check_something
 #   *.foo || another_check 1 2 3
 
+# List of custom NHC configuration files
+nhc_custom_configs: []
+
 nhc_packages: nhc
 
 # List of custom NHC scripts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,18 @@
     group: root
     mode: "0640"
 
+- name: Configure custom NHC configuration files
+  loop: "{{ nhc_custom_configs }}"
+  loop_control:
+    label: "Configure /etc/nhc/{{ item.name }}"
+  when: item.state is not defined or item.state != 'absent'
+  ansible.builtin.copy:
+    content: "{{ item.config | mandatory }}"
+    dest: "/etc/nhc/{{ item.name | mandatory }}"
+    owner: root
+    group: root
+    mode: "0640"
+
 - name: Configure NHC variables
   when: nhc_variables is defined
   ansible.builtin.template:
@@ -46,4 +58,15 @@
     - item.state == 'absent'
   ansible.builtin.file:
     path: "{{ item.dest | default('/etc/nhc/scripts/' + item.src | basename) }}"
+    state: absent
+
+- name: Remove NHC custom configuration files
+  loop: "{{ nhc_custom_configs }}"
+  loop_control:
+    label: "Remove /etc/nhc/{{ item.name }}"
+  when:
+    - item.state is defined
+    - item.state == 'absent'
+  ansible.builtin.file:
+    path: "/etc/nhc/{{ item.name | mandatory }}"
     state: absent


### PR DESCRIPTION
Allows to define more than one NHC config file with a new variable `nhc_custom_configs`. This is a list with three parameters supported:

- name: name of the file (/etc/nhc/{{ name }})
- config: content of the NHC configuration file
- state: present (default) or absent